### PR TITLE
Fix build on Linux and correctly cobmine paths

### DIFF
--- a/Core/UA Core Library.csproj
+++ b/Core/UA Core Library.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/ModelCompiler/ModelDesignerValidator.cs
+++ b/ModelCompiler/ModelDesignerValidator.cs
@@ -277,12 +277,12 @@ namespace Opc.Ua.ModelCompiler
 
             if (!File.Exists(designFilePath))
             {
-                designFilePath = Utils.Format("{0}\\{1}", targetFile.DirectoryName, designFileName);
+                designFilePath = Path.Combine(targetFile.DirectoryName, designFileName);
                 Console.WriteLine("Trying file: " + designFilePath);
 
                 if (!File.Exists(designFilePath))
                 {
-                    designFilePath = Utils.Format(".\\Design\\{0}", designFileName);
+                    designFilePath = Path.Combine(".", "Design", designFileName);
                     Console.WriteLine("Trying file: " + designFilePath);
 
                     if (!File.Exists(designFilePath))
@@ -408,12 +408,12 @@ namespace Opc.Ua.ModelCompiler
 
             if (!File.Exists(identifiersFilePath))
             {
-                identifiersFilePath = Utils.Format("{0}\\{1}", targetFile.DirectoryName, identifiersFileName);
+                identifiersFilePath = Path.Combine(targetFile.DirectoryName, identifiersFileName);
                 Console.WriteLine("Trying file: " + identifiersFilePath);
 
                 if (!File.Exists(identifiersFilePath))
                 {
-                    identifiersFilePath = Utils.Format(".\\Design\\{0}", identifiersFileName);
+                    identifiersFilePath = Path.Combine(".", "Design", identifiersFileName);
                     Console.WriteLine("Trying file: " + identifiersFilePath);
 
                     if (!File.Exists(identifiersFilePath))

--- a/ModelCompiler/ModelGenerator2.cs
+++ b/ModelCompiler/ModelGenerator2.cs
@@ -199,12 +199,12 @@ namespace Opc.Ua.ModelCompiler
 
                         if (references.Count > 0 && references[0].TargetId == Opc.Ua.ObjectIds.XmlSchema_TypeSystem)
                         {
-                            file = String.Format(@"{0}\{1}.Types.xsd", filePath, m_model.TargetNamespaceInfo.Prefix);
+                            file = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.xsd");
                         }
 
                         if (references.Count > 0 && references[0].TargetId == Opc.Ua.ObjectIds.OPCBinarySchema_TypeSystem)
                         {
-                            file = String.Format(@"{0}\{1}.Types.bsd", filePath, m_model.TargetNamespaceInfo.Prefix);
+                            file = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.bsd");
                         }
 
                         if (file != null)
@@ -225,7 +225,7 @@ namespace Opc.Ua.ModelCompiler
             // save the subsets.
             foreach (KeyValuePair<uint,NodeStateCollection> entry in subsets)
             {
-                string file = String.Format(@"{0}\{1}.NodeSet2.Part{2}.xml", filePath, m_model.TargetNamespaceInfo.Prefix, entry.Key);
+                string file = Path.Combine(filePath, String.Format(@"{0}.NodeSet2.Part{1}.xml", m_model.TargetNamespaceInfo.Prefix, entry.Key));
 
                 using (Stream ostrm = File.Open(file, FileMode.Create))
                 {
@@ -244,7 +244,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // open the output file.
-            string outputFile = String.Format(@"{0}\{1}.PredefinedNodes.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".PredefinedNodes.xml");
 
             // save the xml.
             using (Stream ostrm = File.Open(outputFile, FileMode.Create))
@@ -261,7 +261,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // save as nodeset.
-            string outputFile2 = String.Format(@"{0}\{1}.NodeSet.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile2 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".NodeSet.xml");
 
             using (Stream ostrm = File.Open(outputFile2, FileMode.Create))
             {
@@ -275,7 +275,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // save as nodeset.
-            string outputFile3 = String.Format(@"{0}\{1}.NodeSet2.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile3 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".NodeSet2.xml");
 
             using (Stream ostrm = File.Open(outputFile3, FileMode.Create))
             {
@@ -304,7 +304,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // open the output file.
-            string outputFile4 = String.Format(@"{0}\{1}.PredefinedNodes.uanodes", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile4 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".PredefinedNodes.uanodes");
 
             // save the xml.
             using (Stream ostrm = File.Open(outputFile4, FileMode.Create))
@@ -320,7 +320,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_identifiers.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_identifiers.h"), false);
 
             try
             {
@@ -359,7 +359,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_exclusions.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_exclusions.h"), false);
 
             try
             {
@@ -486,7 +486,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_browsenames.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_browsenames.h"), false);
 
             try
             {
@@ -542,7 +542,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_XmlSchema(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Types.xsd", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.xsd"), false);
 
             try
             {
@@ -1180,7 +1180,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_BinarySchema(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Types.bsd", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.bsd"), false);
 
             try
             {
@@ -1615,7 +1615,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_InternalSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Classes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Classes.cs"), false);
 
             try
             {
@@ -1704,7 +1704,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_ConstantsSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Constants.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Constants.cs"), false);
 
             try
             {
@@ -1784,7 +1784,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_DataTypesSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.DataTypes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".DataTypes.cs"), false);
 
             try
             {
@@ -1846,7 +1846,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_NonDataTypesSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Classes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Classes.cs"), false);
 
             try
             {


### PR DESCRIPTION
This fix allows to build the model compiler on Linux using:
`xbuild "ModelCompiler Solution.sln" /p:TargetFrameworkVersion="v4.5"`

Then you can use the model compiler also on Linux (Tested with Ubuntu 16.04)