### PR TITLE
Support of loose coupling with different interface versions for structures.

### DIFF
--- a/ModelCompiler/StackGenerator/DotNet/Templates/Classes/Class.cs
+++ b/ModelCompiler/StackGenerator/DotNet/Templates/Classes/Class.cs
@@ -81,7 +81,11 @@ public partial class _NAME_ : _BASETYPE_
         base.Decode(decoder);
 
         decoder.PushNamespace(Namespaces._TypesNamespace_);
-        // _DECODELIST_
+        try
+        {
+            // _DECODELIST_
+        }
+        catch (System.IO.EndOfStreamException) { }
         decoder.PopNamespace();
     }
 

--- a/ModelCompiler/Templates/Version2/DataTypes/Class.cs
+++ b/ModelCompiler/Templates/Version2/DataTypes/Class.cs
@@ -75,7 +75,11 @@ public partial class _BrowseName_ : IEncodeable
     {
         decoder.PushNamespace(_XmlNamespaceUri_);
 
-        // ListOfDecodedFields
+        try
+        {
+            // ListOfDecodedFields
+        }
+        catch (System.IO.EndOfStreamException) { }
 
         decoder.PopNamespace();
     }

--- a/ModelCompiler/Templates/Version2/DataTypes/DerivedClass.cs
+++ b/ModelCompiler/Templates/Version2/DataTypes/DerivedClass.cs
@@ -79,7 +79,11 @@ public partial class _BrowseName_ : _BaseType_
 
         decoder.PushNamespace(_XmlNamespaceUri_);
 
-        // ListOfDecodedFields
+        try
+        {
+            // ListOfDecodedFields
+        }
+        catch (System.IO.EndOfStreamException) { }
 
         decoder.PopNamespace();
     }


### PR DESCRIPTION
In a client-server system, client and server are usually distributed independently of each other. For this reason, the communication partners may have different versions of the interface. Certain strategies can be used to ensure compatibility.
One possibility is to only add fields at the end of "ua:structure". If, for example, a client with a newer interface receives an event from a server with an older interface, a "System.IO.EndOfStreamException" is triggered during decoding because less data has arrived than expected. By catching this exception, the new fields are in the initial state and the older fields are filled with the received values.
Thus, the non-functional requirement of loose coupling can be supported.