### PR TITLE
Fix build on Linux and correctly cobmine paths

### DIFF
--- a/Core/UA Core Library.csproj
+++ b/Core/UA Core Library.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/ModelCompiler/ModelDesignerValidator.cs
+++ b/ModelCompiler/ModelDesignerValidator.cs
@@ -283,21 +283,21 @@ namespace Opc.Ua.ModelCompiler
 
             if (!File.Exists(designFilePath))
             {
-                designFilePath = Utils.Format("{0}\\{1}", targetFile.DirectoryName, designFileName);
+                designFilePath = Path.Combine(targetFile.DirectoryName, designFileName);
                 Console.WriteLine("Trying file: " + designFilePath);
 
                 if (!File.Exists(designFilePath))
                 {
-                    designFilePath = $".\\Design\\";
+                    designFilePath = Path.Combine(".", "Design");
 
                     int index = EmbeddedResourcePath.IndexOf(".Design");
 
                     if (index > 0)
                     {
-                        designFilePath = $".\\{EmbeddedResourcePath.Substring(index + 1)}\\";
+                        designFilePath = Path.Combine(".", EmbeddedResourcePath.Substring(index + 1));
                     }
 
-                    designFilePath += $"{designFileName}";
+                    designFilePath = Path.Combine(designFilePath, designFileName);
                     Console.WriteLine("Trying file: " + designFilePath);
 
                     if (!File.Exists(designFilePath))
@@ -431,21 +431,21 @@ namespace Opc.Ua.ModelCompiler
 
             if (!File.Exists(identifiersFilePath))
             {
-                identifiersFilePath = Utils.Format("{0}\\{1}", targetFile.DirectoryName, identifiersFileName);
+                identifiersFilePath = Path.Combine(targetFile.DirectoryName, identifiersFileName);
                 Console.WriteLine("Trying file: " + identifiersFilePath);
 
                 if (!File.Exists(identifiersFilePath))
                 {
-                    identifiersFilePath = $".\\Design\\";
+                    identifiersFilePath = Path.Combine(".", "Design");
 
                     int index = EmbeddedResourcePath.IndexOf(".Design");
 
                     if (index > 0)
                     {
-                        identifiersFilePath = $".\\{EmbeddedResourcePath.Substring(index+1)}\\";
+                        identifiersFilePath = Path.Combine(".", EmbeddedResourcePath.Substring(index+1));
                     }
 
-                    identifiersFilePath += $"{identifiersFileName}";
+                    identifiersFilePath = Path.Combine(identifiersFilePath, identifiersFileName);
                     Console.WriteLine("Trying file: " + identifiersFilePath);
 
                     if (!File.Exists(identifiersFilePath))

--- a/ModelCompiler/ModelGenerator2.cs
+++ b/ModelCompiler/ModelGenerator2.cs
@@ -235,12 +235,12 @@ namespace Opc.Ua.ModelCompiler
 
                         if (references.Count > 0 && references[0].TargetId == Opc.Ua.ObjectIds.XmlSchema_TypeSystem)
                         {
-                            file = String.Format(@"{0}\{1}.Types.xsd", filePath, m_model.TargetNamespaceInfo.Prefix);
+                            file = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.xsd");
                         }
 
                         if (references.Count > 0 && references[0].TargetId == Opc.Ua.ObjectIds.OPCBinarySchema_TypeSystem)
                         {
-                            file = String.Format(@"{0}\{1}.Types.bsd", filePath, m_model.TargetNamespaceInfo.Prefix);
+                            file = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.bsd");
                         }
 
                         if (file != null)
@@ -261,7 +261,7 @@ namespace Opc.Ua.ModelCompiler
             // save the subsets.
             foreach (KeyValuePair<uint,NodeStateCollection> entry in subsets)
             {
-                string file = String.Format(@"{0}\{1}.NodeSet2.Part{2}.xml", filePath, m_model.TargetNamespaceInfo.Prefix, entry.Key);
+                string file = Path.Combine(filePath, String.Format(@"{0}.NodeSet2.Part{1}.xml", m_model.TargetNamespaceInfo.Prefix, entry.Key));
 
                 using (Stream ostrm = File.Open(file, FileMode.Create))
                 {
@@ -281,7 +281,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // open the output file.
-            string outputFile = String.Format(@"{0}\{1}.PredefinedNodes.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".PredefinedNodes.xml");
 
             // save the xml.
             using (Stream ostrm = File.Open(outputFile, FileMode.Create))
@@ -298,7 +298,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // save as nodeset.
-            string outputFile2 = String.Format(@"{0}\{1}.NodeSet.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile2 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".NodeSet.xml");
 
             using (Stream ostrm = File.Open(outputFile2, FileMode.Create))
             {
@@ -312,7 +312,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // save as nodeset.
-            string outputFile3 = String.Format(@"{0}\{1}.NodeSet2.xml", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile3 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".NodeSet2.xml");
 
             using (Stream ostrm = File.Open(outputFile3, FileMode.Create))
             {
@@ -361,7 +361,7 @@ namespace Opc.Ua.ModelCompiler
             }
 
             // open the output file.
-            string outputFile4 = String.Format(@"{0}\{1}.PredefinedNodes.uanodes", filePath, m_model.TargetNamespaceInfo.Prefix);
+            string outputFile4 = Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".PredefinedNodes.uanodes");
 
             // save the xml.
             using (Stream ostrm = File.Open(outputFile4, FileMode.Create))
@@ -377,7 +377,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_identifiers.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_identifiers.h"), false);
 
             try
             {
@@ -416,7 +416,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_exclusions.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_exclusions.h"), false);
 
             try
             {
@@ -543,7 +543,7 @@ namespace Opc.Ua.ModelCompiler
         {
             string prefix = m_model.TargetNamespaceInfo.Name;
 
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}_browsenames.h", filePath, prefix.ToLower()), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, prefix.ToLower() + "_browsenames.h"), false);
 
             try
             {
@@ -599,7 +599,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_XmlSchema(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Types.xsd", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.xsd"), false);
 
             try
             {
@@ -1237,7 +1237,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_BinarySchema(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Types.bsd", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Types.bsd"), false);
 
             try
             {
@@ -1673,7 +1673,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_InternalSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Classes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Classes.cs"), false);
 
             try
             {
@@ -1762,7 +1762,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_ConstantsSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Constants.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Constants.cs"), false);
 
             try
             {
@@ -1842,7 +1842,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_DataTypesSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.DataTypes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".DataTypes.cs"), false);
 
             try
             {
@@ -1904,7 +1904,7 @@ namespace Opc.Ua.ModelCompiler
         /// </summary>
         private void WriteTemplate_NonDataTypesSingleFile(string filePath, List<NodeDesign> nodes)
         {
-            StreamWriter writer = new StreamWriter(String.Format(@"{0}\{1}.Classes.cs", filePath, m_model.TargetNamespaceInfo.Prefix), false);
+            StreamWriter writer = new StreamWriter(Path.Combine(filePath, m_model.TargetNamespaceInfo.Prefix + ".Classes.cs"), false);
 
             try
             {


### PR DESCRIPTION
This fix allows to build the model compiler on Linux using:
`msbuild "ModelCompiler Solution.sln" /p:TargetFrameworkVersion="v4.5"`

Replaces #20 