### PR TITLE
Fix output for Enumeration type in structure.

### DIFF
--- a/ModelCompiler/ModelGenerator2.cs
+++ b/ModelCompiler/ModelGenerator2.cs
@@ -1677,7 +1677,7 @@ namespace Opc.Ua.ModelCompiler
                             return GetBinaryDataType((DataTypeDesign)dataType.BaseTypeNode);
                         }
 
-                        return String.Format("ua:Int32");
+                        return String.Format("opc:Int32");
                     }
 
                     string prefix = "tns";


### PR DESCRIPTION

It used ua:Int32 instead of opc:Int32, causing error in validating the type dictionary.
e.g. was
```
<opc:StructuredType Name="ScalarValueDataType" BaseType="ua:ExtensionObject">
    <opc:Field Name="BooleanValue" TypeName="opc:Boolean" />
    <opc:Field Name="VariantValue" TypeName="ua:Variant" />
   <opc:Field Name="EnumerationValue" TypeName="ua:Int32" />
    <opc:Field Name="StructureValue" TypeName="ua:ExtensionObject" />
  </opc:StructuredType>
```
is now
```
<opc:StructuredType Name="ScalarValueDataType" BaseType="ua:ExtensionObject">
    <opc:Field Name="BooleanValue" TypeName="opc:Boolean" />
    <opc:Field Name="VariantValue" TypeName="ua:Variant" />
    <opc:Field Name="EnumerationValue" TypeName="opc:Int32" />
    <opc:Field Name="StructureValue" TypeName="ua:ExtensionObject" />
  </opc:StructuredType>
```