### PR TITLE
Add base.Initialize(context) to ObjectType.cs, VariableType.cs and MethodType.cs

### DIFF
--- a/ModelCompiler/Templates/Version2/MethodType.cs
+++ b/ModelCompiler/Templates/Version2/MethodType.cs
@@ -32,6 +32,7 @@ public partial class _ClassName_ : MethodState
     /// </summary>
     protected override void Initialize(ISystemContext context)
     {
+        base.Initialize(context);
         Initialize(context, InitializationString);
         InitializeOptionalChildren(context);
     }

--- a/ModelCompiler/Templates/Version2/ObjectType.cs
+++ b/ModelCompiler/Templates/Version2/ObjectType.cs
@@ -91,6 +91,7 @@ public partial class _ClassName_State : _BaseClassName_State<BaseT>
     /// </summary>
     protected override void Initialize(ISystemContext context)
     {
+        base.Initialize(context);
         Initialize(context, InitializationString);
         InitializeOptionalChildren(context);
     }

--- a/ModelCompiler/Templates/Version2/VariableType.cs
+++ b/ModelCompiler/Templates/Version2/VariableType.cs
@@ -107,6 +107,7 @@ public partial class _ClassName_State : _BaseClassName_State<BaseT>
     /// </summary>
     protected override void Initialize(ISystemContext context)
     {
+        base.Initialize(context);
         Initialize(context, InitializationString);
         InitializeOptionalChildren(context);
     }


### PR DESCRIPTION
Optional properties,... from subtyped types were missing on creation.

Should fix [#1004](https://github.com/OPCFoundation/UA-.NETStandard/issues/1004)