### PR TITLE
Enhance generated code for structures with properties, support ICloneable in .NET standard

### DIFF
--- a/Opc.Ua.ModelCompiler/ModelGenerator2.cs
+++ b/Opc.Ua.ModelCompiler/ModelGenerator2.cs
@@ -3395,6 +3395,14 @@ namespace ModelCompiler
 
             AddTemplate(
                 template,
+                "// ListOfUpdateChildrenChangeMasks",
+                null,
+                fields,
+                new LoadTemplateEventHandler(WriteTemplate_VariableTypeValueUpdateChildrenChangeMasks),
+                null);
+
+            AddTemplate(
+                template,
                 "// ListOfChildMethods",
                 TemplatePath + "Version2.VariableTypeValueField.cs",
                 fields,
@@ -3427,13 +3435,48 @@ namespace ModelCompiler
             template.Write("instance = m_variable.{0};", path);
 
             template.WriteNextLine(context.Prefix);
-            template.Write("instance.OnReadValue = OnRead_{0};", name);
+            template.Write("if (instance != null)");
 
             template.WriteNextLine(context.Prefix);
-            template.Write("instance.OnSimpleWriteValue = OnWrite_{0};", name);
+            template.Write("{");
 
             template.WriteNextLine(context.Prefix);
-            template.Write("updateList.Add(instance);");
+            template.Write("    instance.OnReadValue = OnRead_{0};", name);
+
+            template.WriteNextLine(context.Prefix);
+            template.Write("    instance.OnWriteValue = OnWrite_{0};", name);
+
+            template.WriteNextLine(context.Prefix);
+            template.Write("    updateList.Add(instance);");
+
+            template.WriteNextLine(context.Prefix);
+            template.Write("}");
+
+            return context.TemplatePath;
+        }
+        #endregion
+
+        #region "// ListOfUpdateChildrenChangeMasks"
+        private string WriteTemplate_VariableTypeValueUpdateChildrenChangeMasks(Template template, Context context)
+        {
+            KeyValuePair<string, Parameter>? field = context.Target as KeyValuePair<string, Parameter>?;
+
+            if (field == null)
+            {
+                return null;
+            }
+
+            if (!context.FirstInList)
+            {
+                template.WriteNextLine(context.Prefix);
+            }
+
+            string name = field.Value.Key;
+            // string path = field.Value.Key.Replace('_', '.');
+            string path = field.Value.Key;
+
+            template.WriteNextLine(context.Prefix);
+            template.Write("if (!Utils.IsEqual(m_value.{0}, newValue.{0})) UpdateChildVariableStatus(m_variable.{0}, ref statusCode, ref timestamp);", path);
 
             return context.TemplatePath;
         }

--- a/Opc.Ua.ModelCompiler/Opc.Ua.ModelCompiler.csproj
+++ b/Opc.Ua.ModelCompiler/Opc.Ua.ModelCompiler.csproj
@@ -298,6 +298,7 @@
     <None Remove="Templates\XmlSchema\EnumeratedType.xml" />
     <None Remove="Templates\XmlSchema\File.xml" />
     <None Remove="Templates\XmlSchema\SimpleType.xml" />
+    <None Remove="Templates\XmlSchema\Union.xml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -511,6 +512,7 @@
     <EmbeddedResource Include="Templates\XmlSchema\EnumeratedType.xml" />
     <EmbeddedResource Include="Templates\XmlSchema\File.xml" />
     <EmbeddedResource Include="Templates\XmlSchema\SimpleType.xml" />
+    <EmbeddedResource Include="Templates\XmlSchema\Union.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Class.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Class.cs
@@ -84,13 +84,11 @@ public partial class _BrowseName_ : IEncodeable, IJsonEncodeable
         return true;
     }
 
-    #if !NET_STANDARD
     /// <summary cref="ICloneable.Clone" />
     public virtual object Clone()
     {
         return (_BrowseName_)this.MemberwiseClone();
     }
-    #endif
 
     /// <summary cref="Object.MemberwiseClone" />
     public new object MemberwiseClone()

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/ClassWithOptionalFields.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/ClassWithOptionalFields.cs
@@ -106,13 +106,11 @@ public partial class _BrowseName_ : IEncodeable, IJsonEncodeable
         return true;
     }
 
-    #if !NET_STANDARD
     /// <summary cref="ICloneable.Clone" />
     public virtual object Clone()
     {
         return (_BrowseName_)this.MemberwiseClone();
     }
-    #endif
 
     /// <summary cref="Object.MemberwiseClone" />
     public new object MemberwiseClone()

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/CollectionClass.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/CollectionClass.cs
@@ -4,11 +4,7 @@
 /// <exclude />
 [System.CodeDom.Compiler.GeneratedCodeAttribute("Opc.Ua.ModelCompiler", "1.0.0.0")]
 [CollectionDataContract(Name = "ListOf_BrowseName_", Namespace = _XmlNamespaceUri_, ItemName = "_BrowseName_")]
-#if !NET_STANDARD
 public partial class _BrowseName_Collection : List<_BrowseName_>, ICloneable
-#else
-public partial class _BrowseName_Collection : List<_BrowseName_>
-#endif
 {
     #region Constructors
     /// <remarks />
@@ -45,7 +41,6 @@ public partial class _BrowseName_Collection : List<_BrowseName_>
     }
     #endregion
 
-    #if !NET_STANDARD
     #region ICloneable Methods
     /// <remarks />
     public object Clone()
@@ -53,7 +48,6 @@ public partial class _BrowseName_Collection : List<_BrowseName_>
         return (_BrowseName_Collection)this.MemberwiseClone();
     }
     #endregion
-    #endif
 
     /// <summary cref="Object.MemberwiseClone" />
     public new object MemberwiseClone()

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/DerivedClass.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/DerivedClass.cs
@@ -88,13 +88,11 @@ public partial class _BrowseName_ : _BaseType_
         return base.IsEqual(encodeable);
     }    
 
-    #if !NET_STANDARD
     /// <summary cref="ICloneable.Clone" />
     public override object Clone()
     {
         return (_BrowseName_)this.MemberwiseClone();
     }
-    #endif
 
     /// <summary cref="Object.MemberwiseClone" />
     public new object MemberwiseClone()

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Union.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Union.cs
@@ -117,13 +117,11 @@ public partial class _BrowseName_ : IEncodeable, IJsonEncodeable
         return true;
     }
 
-    #if !NET_STANDARD
     /// <summary cref="ICloneable.Clone" />
     public virtual object Clone()
     {
         return (_BrowseName_)this.MemberwiseClone();
     }
-    #endif
 
     /// <summary cref="Object.MemberwiseClone" />
     public new object MemberwiseClone()

--- a/Opc.Ua.ModelCompiler/Templates/Version2/VariableTypeValue.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/VariableTypeValue.cs
@@ -125,7 +125,7 @@ public class _ClassName_Value : BaseVariableValue
         m_variable.ClearChangeMasks(context, false);
     }
 
-    private void UpdateChildVariableStatus(BaseDataVariableState child, ref StatusCode statusCode, ref DateTime timestamp)
+    private void UpdateChildVariableStatus(BaseVariableState child, ref StatusCode statusCode, ref DateTime timestamp)
     {
         if (child == null) return;
         child.StatusCode = statusCode;

--- a/Opc.Ua.ModelCompiler/Templates/Version2/VariableTypeValueField.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/VariableTypeValueField.cs
@@ -1,4 +1,5 @@
-public class _ClassName_Value {
+public class _ClassName_Value
+{
 // ***START***
 #region _ChildName_ Access Methods
 /// <remarks />
@@ -15,21 +16,50 @@ private ServiceResult OnRead__ChildName_(
     {
         DoBeforeReadProcessing(context, node);
 
+        var childVariable = m_variable?._ChildPath_;
+        if (childVariable != null && StatusCode.IsBad(childVariable.StatusCode))
+        {
+            value = null;
+            statusCode = childVariable.StatusCode;
+            return new ServiceResult(statusCode);
+        }
+
         if (m_value != null)
         {
             value = m_value._ChildPath_;
         }
 
-        return Read(context, node, indexRange, dataEncoding, ref value, ref statusCode, ref timestamp);
+        var result = Read(context, node, indexRange, dataEncoding, ref value, ref statusCode, ref timestamp);
+
+        if (childVariable != null && ServiceResult.IsNotBad(result))
+        {
+            timestamp = childVariable.Timestamp;
+            if (statusCode != childVariable.StatusCode)
+            {
+                statusCode = childVariable.StatusCode;
+                result = new ServiceResult(statusCode);
+            }
+        }
+
+        return result;
     }
 }
 
 /// <remarks />
-private ServiceResult OnWrite__ChildName_(ISystemContext context, NodeState node, ref object value)
+private ServiceResult OnWrite__ChildName_(
+    ISystemContext context,
+    NodeState node,
+    NumericRange indexRange,
+    QualifiedName dataEncoding,
+    ref object value,
+    ref StatusCode statusCode,
+    ref DateTime timestamp)
 {
     lock (Lock)
     {
+        UpdateChildVariableStatus(m_variable._ChildPath_, ref statusCode, ref timestamp);
         m_value._ChildPath_ = (_ChildDataType_)Write(value);
+        UpdateParent(context, ref statusCode, ref timestamp);
     }
 
     return ServiceResult.Good;


### PR DESCRIPTION
* support ICloneable with NET_STANDARD, it is not required anymore to comment out
* updates for generated code with complex types with variables. 
The existing implementation did not track the timestamps of the properties and subscriptions did not work. 
* For sample implementation using this update see PR: https://github.com/OPCFoundation/UA-.NETStandard/pull/2008