### PR TITLE
Added option to generate actual abstract classes for abstract OPC UA DataTypes

### DIFF
--- a/Opc.Ua.ModelCompiler/ModelGenerator2.cs
+++ b/Opc.Ua.ModelCompiler/ModelGenerator2.cs
@@ -3233,6 +3233,14 @@ namespace ModelCompiler
 
             if (dataType != null)
             {
+                if (dataType.IsAbstract)
+                {
+                    template.AddReplacement("_IsAbstract_", "abstract");
+                }
+                else
+                {
+                    template.AddReplacement("_IsAbstract_", String.Empty);
+                }
                 if (!dataType.IsOptionSet)
                 {
                     template.AddReplacement("[Flags]", String.Empty);

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Class.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/Class.cs
@@ -6,7 +6,7 @@ namespace X {
 /// <exclude />
 [System.CodeDom.Compiler.GeneratedCodeAttribute("Opc.Ua.ModelCompiler", "1.0.0.0")]
 [DataContract(Namespace = _XmlNamespaceUri_)]
-public partial class _BrowseName_ : IEncodeable, IJsonEncodeable
+public _IsAbstract_ partial class _BrowseName_ : IEncodeable, IJsonEncodeable
 {
     #region Constructors
     /// <remarks />


### PR DESCRIPTION
As mentioned in https://github.com/OPCFoundation/UA-ModelCompiler/issues/149 the modelcompiler currently can not properly generate abstract datatypes. 
This is due to the missing abstract keyword in the generated code - see full explanation in the linked issue. 
To fix this, I've simply added a placeholder to the classes template the allows the code generator to add the abstract keyword, if the datatype thats being generated is abstract. If it's not abstract, the placeholder is simply removed.