### PR TITLE
Fix for indexing nodes by id with string based ids

### DIFF
--- a/Opc.Ua.ModelCompiler/ModelDesignerValidator.cs
+++ b/Opc.Ua.ModelCompiler/ModelDesignerValidator.cs
@@ -1009,11 +1009,14 @@ namespace ModelCompiler
             NodeDesign parent)
         {
             foreach (var node in nodes)
-            {
-                if (node.NumericIdSpecified && node.NumericId > 0)
+            {                
+                var hasNumericId = node.NumericIdSpecified && node.NumericId > 0;
+                var hasStringId = !node.NumericIdSpecified && !string.IsNullOrEmpty(node.StringId);
+                
+                if (hasNumericId || hasStringId)
                 {
                     var nodeId = new NodeId(
-                        node.NumericId,
+                        hasNumericId ? node.NumericId : node.StringId,
                         namespaceUris.GetIndexOrAppend(node.SymbolicId.Namespace));
 
                     index[nodeId] = node;


### PR DESCRIPTION
When compiling the Padim node set, the IRDI dictionary references are missing in the generated C# classes. This is because string based node ids are currently not considered by the `ModelDesignerValidator`.