### PR TITLE
Allow custom base types for structures with optional fields

### DIFF
--- a/Opc.Ua.ModelCompiler/DesignQueryExtensions.cs
+++ b/Opc.Ua.ModelCompiler/DesignQueryExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace ModelCompiler
+{
+    internal static class DesignQueryExtensions
+    {
+        public static bool HasOptionalFields(this DataTypeDesign dataType)
+        {
+            return dataType.HasFields && dataType.Fields.Any(field => field.IsOptional);
+        }
+
+        public static bool HasBaseStructureBaseType(this DataTypeDesign dataType)
+        {
+            return ((DataTypeDesign)dataType.BaseTypeNode).BasicDataType == BasicDataType.Structure;
+        }
+
+        public static bool HasCustomBaseType(this DataTypeDesign dataType)
+        {
+            return ((DataTypeDesign)dataType.BaseTypeNode).BasicDataType == BasicDataType.UserDefined;
+        }
+    }
+}

--- a/Opc.Ua.ModelCompiler/ModelGenerator2.cs
+++ b/Opc.Ua.ModelCompiler/ModelGenerator2.cs
@@ -3085,14 +3085,14 @@ namespace ModelCompiler
                             return TemplatePath + "Version2.DataTypes.Union.cs";
                         }
 
-                        if (datatype.HasFields && datatype.Fields.Where(x => x.IsOptional).Count() > 0)
+                        if (datatype.HasBaseStructureBaseType())
                         {
-                            return TemplatePath + "Version2.DataTypes.ClassWithOptionalFields.cs";
+                            return DetermineTemplate_StructureWithBaseStructureSuperType(datatype, TemplatePath);
                         }
 
-                        if (GetBaseClassName(datatype) == "IEncodeable")
+                        if (datatype.HasCustomBaseType())
                         {
-                            return TemplatePath + "Version2.DataTypes.Class.cs";
+                            return DetermineTemplate_StructureWithCustomSuperType(datatype, TemplatePath);
                         }
 
                         return TemplatePath + "Version2.DataTypes.DerivedClass.cs";
@@ -3150,6 +3150,20 @@ namespace ModelCompiler
             }
 
             return null;
+        }
+        
+        private static string DetermineTemplate_StructureWithBaseStructureSuperType(DataTypeDesign dataType, string templatePath)
+        {
+            return dataType.HasOptionalFields()
+                ? templatePath + "Version2.DataTypes.ClassWithOptionalFields.cs"
+                : templatePath + "Version2.DataTypes.Class.cs";
+        }
+
+        private static string DetermineTemplate_StructureWithCustomSuperType(DataTypeDesign dataType, string templatePath)
+        {
+            return dataType.HasOptionalFields()
+                ? TemplatePath + "Version2.DataTypes.DerivedClassWithOptionalFields.cs"
+                : TemplatePath + "Version2.DataTypes.DerivedClass.cs";
         }
 
         /// <summary>

--- a/Opc.Ua.ModelCompiler/Opc.Ua.ModelCompiler.csproj
+++ b/Opc.Ua.ModelCompiler/Opc.Ua.ModelCompiler.csproj
@@ -128,6 +128,7 @@
     <Compile Remove="Templates\Version2\DataTypes\ClassWithOptionalFields.cs" />
     <Compile Remove="Templates\Version2\DataTypes\CollectionClass.cs" />
     <Compile Remove="Templates\Version2\DataTypes\DerivedClass.cs" />
+    <Compile Remove="Templates\Version2\DataTypes\DerivedClassWithOptionalFields.cs" />
     <Compile Remove="Templates\Version2\DataTypes\Enumeration.cs" />
     <Compile Remove="Templates\Version2\DataTypes\EnumerationValue.cs" />
     <Compile Remove="Templates\Version2\DataTypes\Property.cs" />
@@ -470,6 +471,7 @@
     <EmbeddedResource Include="Templates\Version2\ConstantsFile.ts" />
     <EmbeddedResource Include="Templates\Version2\DataTypes\ArrayProperty.cs" />
     <EmbeddedResource Include="Templates\Version2\DataTypes\Class.cs" />
+    <EmbeddedResource Include="Templates\Version2\DataTypes\DerivedClassWithOptionalFields.cs" />
     <EmbeddedResource Include="Templates\Version2\DataTypes\ClassWithOptionalFields.cs" />
     <EmbeddedResource Include="Templates\Version2\DataTypes\CollectionClass.cs" />
     <EmbeddedResource Include="Templates\Version2\DataTypes\DerivedClass.cs" />

--- a/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/DerivedClassWithOptionalFields.cs
+++ b/Opc.Ua.ModelCompiler/Templates/Version2/DataTypes/DerivedClassWithOptionalFields.cs
@@ -1,0 +1,142 @@
+namespace X
+{
+    // ***START***
+    #region _BrowseName_ Class
+#if (!OPCUA_EXCLUDE__BrowseName_)
+    /// <remarks />
+    /// <exclude />
+    [Flags]
+    public enum _ClassName_Fields : uint
+    {
+        None = 0,
+        // ListOfEncodingMaskFields
+    }
+
+    /// <remarks />
+    /// <exclude />
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Opc.Ua.ModelCompiler", "1.0.0.0")]
+    [DataContract(Namespace = _XmlNamespaceUri_)]
+    public partial class _BrowseName_ : _BaseType_
+    {
+        #region Constructors
+        /// <remarks />
+        public _BrowseName_()
+        {
+            Initialize();
+        }
+
+        [OnDeserializing]
+        private void Initialize(StreamingContext context)
+        {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            EncodingMask = _ClassName_Fields.None;
+            // ListOfFieldInitializers
+        }
+        #endregion
+
+        #region Public Properties
+        // <remarks />
+        [DataMember(Name = "EncodingMask", IsRequired = true, Order = 0)]
+        public _ClassName_Fields EncodingMask { get; set; }
+
+        // ListOfProperties
+        #endregion
+
+        #region IEncodeable Members
+        /// <summary cref="IEncodeable.TypeId" />
+        public override ExpandedNodeId TypeId => DataTypeIds._BrowseName_;
+
+        /// <summary cref="IEncodeable.BinaryEncodingId" />
+        public override ExpandedNodeId BinaryEncodingId => ObjectIds._BrowseName__Encoding_DefaultBinary;
+
+        /// <summary cref="IEncodeable.XmlEncodingId" />
+        public override ExpandedNodeId XmlEncodingId => ObjectIds._BrowseName__Encoding_DefaultXml;
+
+        /// <summary cref="IJsonEncodeable.JsonEncodingId" />
+        public override ExpandedNodeId JsonEncodingId => ObjectIds._BrowseName__Encoding_DefaultJson;
+
+        /// <summary cref="IEncodeable.Encode(IEncoder)" />
+        public override void Encode(IEncoder encoder)
+        {
+            base.Encode(encoder);
+
+            encoder.PushNamespace(_XmlNamespaceUri_);
+            encoder.WriteUInt32(nameof(EncodingMask), (uint)EncodingMask);
+
+            // ListOfEncodedFields
+
+            encoder.PopNamespace();
+        }
+
+        /// <summary cref="IEncodeable.Decode(IDecoder)" />
+        public override void Decode(IDecoder decoder)
+        {
+            base.Decode(decoder);
+
+            decoder.PushNamespace(_XmlNamespaceUri_);
+
+            EncodingMask = (_ClassName_Fields)decoder.ReadUInt32(nameof(EncodingMask));
+
+            // ListOfDecodedFields
+
+            decoder.PopNamespace();
+        }
+
+        /// <summary cref="IEncodeable.IsEqual(IEncodeable)" />
+        public override bool IsEqual(IEncodeable encodeable)
+        {
+            if (Object.ReferenceEquals(this, encodeable))
+            {
+                return true;
+            }
+
+#if NET6_0_OR_GREATER
+            _BrowseName_? value = encodeable as _BrowseName_;
+#else
+            _BrowseName_ value = encodeable as _BrowseName_;
+#endif
+
+            if (value == null)
+            {
+                return false;
+            }
+
+            if (value.EncodingMask != this.EncodingMask) return false;
+
+            // ListOfComparedFields
+
+            return true;
+        }
+
+        /// <summary cref="ICloneable.Clone" />
+        public override object Clone()
+        {
+            return (_BrowseName_)this.MemberwiseClone();
+        }
+
+        /// <summary cref="Object.MemberwiseClone" />
+        public new object MemberwiseClone()
+        {
+            _BrowseName_ clone = (_BrowseName_)base.MemberwiseClone();
+
+            clone.EncodingMask = this.EncodingMask;
+
+            // ListOfClonedFields
+
+            return clone;
+        }
+        #endregion
+
+        #region Private Fields
+        // ListOfFields
+        #endregion
+    }
+    // CollectionClass
+#endif
+    #endregion
+    // ***END***
+}


### PR DESCRIPTION
This a proposed solution to the issue #192. 

Extends the templates with a data type template that allows a structure with optional fields to subtype from a custom structure. The template is a copy of the `ClassWithOptionalFields.cs` with a couple of changes, mainly caused by replacing `virtual` with `override`.