### PR TITLE
fix BuildModel.bat path

### DIFF
--- a/Tests/DemoModel/BuildModel.bat
+++ b/Tests/DemoModel/BuildModel.bat
@@ -1,7 +1,7 @@
 @ECHO off
 SETLOCAL
 
-set MODELCOMPILER=..\..\..\build\bin\Release\net9.0\Opc.Ua.ModelCompiler.exe
+set MODELCOMPILER=..\..\build\bin\Release\net9.0\Opc.Ua.ModelCompiler.exe
 set MODEL=DemoModel
 set VERSION=v105
 set EXCLUDE=Draft


### PR DESCRIPTION
got broken in https://github.com/OPCFoundation/UA-ModelCompiler/commit/02eb6cb8acd5b4401b73cff83b477308810e30a4

Repro:
- clone this repo
- compile solution file with Release configuration
- and execute  the Buildmodel.bat in opened cmd

previous try:
https://github.com/OPCFoundation/UA-ModelCompiler/pull/225