### PR TITLE
Fix code generation for NodeIds and BrowseNames containing special characters

### DIFF
--- a/Opc.Ua.ModelCompiler/ModelGenerator2.cs
+++ b/Opc.Ua.ModelCompiler/ModelGenerator2.cs
@@ -2736,7 +2736,7 @@ namespace ModelCompiler
             context.BlankLine = false;
 
             template.AddReplacement("_Key_", name.Value.Key);
-            template.AddReplacement("_Value_", name.Value.Value);
+            template.AddReplacement("_Value_", EscapeStringLiteral(name.Value.Value));
 
             return template.WriteTemplate(context);
         }
@@ -2836,7 +2836,7 @@ namespace ModelCompiler
             }
             else if (!string.IsNullOrEmpty(node.StringId))
             {
-                template.AddReplacement("_Value_", $"s={node.StringId}");
+                template.AddReplacement("_Value_", $"s={EscapeStringLiteral(node.StringId)}");
             }
 
             return template.WriteTemplate(context);
@@ -3058,7 +3058,7 @@ namespace ModelCompiler
             }
             else
             {
-                id = $"\"{node.StringId}\"";
+                id = $"\"{EscapeStringLiteral(node.StringId)}\"";
                 idType = "string";
             }
 
@@ -3282,7 +3282,7 @@ namespace ModelCompiler
             }
 
             template.AddReplacement("_SymbolicName_", browseName.Value.Key);
-            template.AddReplacement("_BrowseName_", browseName.Value.Value);
+            template.AddReplacement("_BrowseName_", EscapeStringLiteral(browseName.Value.Value));
 
             return template.WriteTemplate(context);
         }
@@ -6231,6 +6231,27 @@ namespace ModelCompiler
             }
 
             return $"<{scalarName}>";
+        }
+
+        private static string EscapeStringLiteral(string value)
+        {
+            StringBuilder output = new();
+
+            foreach (var ch in value)
+            {
+                switch (ch)
+                {
+                    case '\\': output.Append("\\\\"); break;
+                    case '"': output.Append("\\\""); break;
+                    case '\n': output.Append("\\n"); break;
+                    case '\r': output.Append("\\r"); break;
+                    case '\t': output.Append("\\t"); break;
+                    case '\0': output.Append("\\0"); break;
+                    default: output.Append(ch); break;
+                }
+            }
+
+            return output.ToString();
         }
 
         /// <summary>

--- a/Opc.Ua.ModelCompiler/NodeSetToModelDesign.cs
+++ b/Opc.Ua.ModelCompiler/NodeSetToModelDesign.cs
@@ -1280,10 +1280,10 @@ namespace ModelCompiler
 
             if (input is UAType)
             {
-                if (output.SymbolicId.Name.EndsWith("_" + nodeId.Identifier.ToString()))
+                if (output.SymbolicId.Name.EndsWith("_" + ToSymbolicName(nodeId.Identifier.ToString())))
                 {
                     output.SymbolicName = new XmlQualifiedName(
-                        $"{output.SymbolicName.Name}_{nodeId.Identifier}",
+                        $"{output.SymbolicName.Name}_{ToSymbolicName(nodeId.Identifier.ToString())}",
                         output.SymbolicName.Namespace);
                 }
             }
@@ -1844,7 +1844,7 @@ namespace ModelCompiler
                 while (m_symbolicIds.Values.Where(x => x == symbolicId).FirstOrDefault() != null)
                 {
                     symbolicId = new XmlQualifiedName(
-                        $"{symbolicId.Name}_{NodeId.Parse(node.NodeId).Identifier}",
+                        $"{symbolicId.Name}_{ToSymbolicName(NodeId.Parse(node.NodeId).Identifier.ToString())}",
                         symbolicId.Namespace);
                 }
 


### PR DESCRIPTION
### Proposed changes

The model compiler produces invalid C# code when processing NodeSet XML files that contain string NodeIds or BrowseNames with characters that are special in C# (", \). Per [OPC 10000-3 v1.05 8.2,](https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2) string NodeId identifiers allow any Unicode characters. Per [OPC 10000-3 v1.05 8.3,](https://reference.opcfoundation.org/Core/Part3/v105/docs/8.3), the name component of a QualifiedName (BrowseName) is also an unrestricted Unicode string. However, the compiler emits these values unescaped into generated .Constants.cs files, breaking string literals and producing invalid C# identifiers.

### How the issue was found
The issue was found when processing a vendor-exported NodeSet containing string NodeIds with embedded double-quote characters (e.g., ns=1;s=AA_"type"). Additionally, the CNC companion spec NodeSet from the official OPCFoundation/UA-Nodeset repository also fails code generation on current master — it contains string NodeIds with dots (e.g., ns=1;s=CncInterface.CncAxisList.X) that produce invalid C# identifiers when used as suffixes.

### What this PR fixes
1.	String literal escaping — Added EscapeForStringLiteral() to properly escape \, ", \n, \r, \t, and \0 when emitting NodeId and BrowseName values into generated C# string constants.
2.	Identifier sanitization — Applied ToSymbolicName() to NodeId identifier strings when they are appended as suffixes to resolve symbolic name collisions.

### Files changed

- ModelGenerator2.cs — Added EscapeForStringLiteral() and applied it in 4 locations where string values are emitted into generated code (WriteTemplate_BrowseName, WriteTemplate_StringId, WriteTemplate_NodeIdValue, WriteTemplate_SymbolicName).

- NodeSetToModelDesign.cs — Wrapped nodeId.Identifier.ToString() with ToSymbolicName() in 3 places where the raw identifier is used as part of a C# identifier suffix.