### PR TITLE
Remove duplicate type check based on BrowseName

### DIFF
--- a/Opc.Ua.ModelCompiler/NodeSetToModelDesign.cs
+++ b/Opc.Ua.ModelCompiler/NodeSetToModelDesign.cs
@@ -1875,7 +1875,6 @@ namespace ModelCompiler
             }
 
             List<NodeDesign> items = new();
-            HashSet<string> typeNames = new();
 
             for (int ii = 0; ii < m_nodeset.Items.Length; ii++)
             {
@@ -1887,16 +1886,6 @@ namespace ModelCompiler
                     {
                         continue;
                     }
-                }
-
-                if (node is UAType type)
-                {
-                    if (typeNames.Contains(type.BrowseName))
-                    {
-                        throw new InvalidOperationException($"{node.NodeId} is a type with a duplicate name.");
-                    }
-
-                    typeNames.Add(type.BrowseName); 
                 }
 
                 NodeId nodeId = ImportNodeId(node.NodeId);


### PR DESCRIPTION
### Proposed changes
Removed the duplicate type detection check that incorrectly rejected valid NodeSet XML files when multiple UAObjectType or UAVariableType nodes share the same BrowseName but have different NodeIds.The removed check compared raw BrowseName strings and threw an InvalidOperationException for types that are perfectly valid per the specification.

Per [OPC 10000-3 5.2.4](https://reference.opcfoundation.org/Core/Part3/v104/docs/5.2): 

> "Unlike NodeIds, the BrowseName cannot be used to unambiguously identify a Node. Different Nodes may have the same BrowseName."


### Why removing the check is safe
The symbolic ID deduplication pass (earlier in the same Import() method) already guarantees that every type receives a unique symbolic name before code generation. NodeId uniqueness is enforced by m_index (a Dictionary<NodeId, UANode>) at construction time. The removed check was redundant and incorrectly used BrowseName as the uniqueness criterion.
### Context
The check was added in commit 0df38b2 ("Sync with member-only repository", Dec 2025) as part of a large bulk sync with no specific justification for this validation.
### Files changed

- NodeSetToModelDesign.cs — Removed HashSet<string> typeNames and the typeNames.Contains(type.BrowseName) check in the Import() method.

### Test notes

- Verified against 7 standard companion spec NodeSets (BACnet, DI, Machinery, Robotics, IRDI, MachineTool, Pumps) — all generate successfully
- Verified against a vendor-exported NodeSet with duplicate BrowseNames across types — compiler now generates code without throwing
-  CNC, PADIM, and PLCopen NodeSets fail on clean master as well (pre-existing unrelated bugs)
